### PR TITLE
FIX: 미세먼지와 꽃가루 정보 따로 출력

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -360,9 +360,14 @@ app.post('/gemini', async (req, res) => {
     return res.json({ reply: '위치 정보를 가져오는 중 오류가 발생했어요.' });
   }
 //우산, 옷차림, 공기질 등등에 대한 답변 이끌어 내는 코드. weatherAdviceRouter.js에서 실행
-// 공기질 + 꽃가루
-if (weatherAdvice.isAirQualityRelated(userInput)) {
+// 공기질
+if (weatherAdvice.isAirRelated(userInput)) {
   return await weatherAdvice.handleAirAdvice({ lat, lon, locationName }, res);
+}
+
+// 꽃가루
+if (weatherAdvice.isPollenRelated(userInput)) {
+  return await weatherAdvice.handlePollenAdvice({ lat, lon, locationName }, res);
 }
 
 // 우산


### PR DESCRIPTION
# 설명
미세먼지 정보랑 꽃가루 정보랑 같이 출력되는 문제가 있었음. 해당 부분을 분리하는 작업을 진행.

# 작업 내용
![image](https://github.com/user-attachments/assets/5ba83bdf-13c2-45a7-a21b-41457c3c1695) ![image](https://github.com/user-attachments/assets/dcb7253a-0303-43fe-8c0a-47571c498fb2)

1. `weatherAdviceRouter.js`에서 `isAirQualityRelated`를 `isAirRelated`와 `isPollenRelated`로 분리하였습니다.
2. `handleAirAdvice`를 `handleAirAdvice`와 `handlePollenAdvice`로 분리하였습니다.